### PR TITLE
Only include instance methods once attr_encrypted is specified

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -133,8 +133,17 @@ if defined?(ActiveRecord::Base)
     end
   end
 
-  ActiveSupport.on_load(:active_record) do
-    extend AttrEncrypted
-    extend AttrEncrypted::Adapters::ActiveRecord
+  if defined?(ActiveSupport.on_load)
+    ActiveSupport.on_load(:active_record) do
+      extend AttrEncrypted
+      extend AttrEncrypted::Adapters::ActiveRecord
+    end
+  else
+    Rails.configuration.to_prepare do
+      ActiveRecord::Base.class_eval do
+        extend AttrEncrypted
+        extend AttrEncrypted::Adapters::ActiveRecord
+      end
+    end
   end
 end


### PR DESCRIPTION
Use the "InstanceMethods" module pattern to isolate the instance methods for attr_encrypted so that they don't infect other ActiveRecord models in the codebase. This resolves some compatibility issues with other libraries that override method_missing